### PR TITLE
bugfixed: how to get array from $config

### DIFF
--- a/classes/Kohana/Pagination.php
+++ b/classes/Kohana/Pagination.php
@@ -109,7 +109,7 @@ class Kohana_Pagination {
         $config['group'] = (string) $group;
 
         // Recursively load requested config groups
-        while (isset($config['group']) AND isset($config_file->$config['group']))
+        while (isset($config['group']) AND isset($config_file->{$config['group']}))
         {
             // Temporarily store config group name
             $group = $config['group'];


### PR DESCRIPTION
In php 7.1, the arrow operator needs to be written as shown on the right. 

e.g.:

```php
$obj->{$keyarr['keyname']}
```